### PR TITLE
Fix dependencies

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,7 +1,7 @@
 #lang info
 (define collection "rchess")
-(define deps '("base" "chess" "brag"))
-(define build-deps '("scribble-lib" "racket-doc" "rackunit-lib"))
+(define deps '("base" "chess" "brag" "htdp-lib" "pict-lib" "rackunit-lib" "rebellion"))
+(define build-deps '("scribble-lib" "racket-doc"))
 (define scribblings '(("scribblings/rchess.scrbl" ())))
 (define pkg-desc "Description Here")
 (define version "0.0")


### PR DESCRIPTION
This pull request fixes the dependencies in `info.rkt`, as the `rchess` package has some dependencies it either doesn't declare or inaccurately declares as build dependencies. The most common reasons this happens are:

- This package uses code from a dependency of a dependency, implicitly relying on the fact that the undeclared dependency will be installed in the process of installing the direct dependency. This means this package will break if the direct dependency stops depending on the undeclared dependency.
- This package declares a `build-dep` dependency but that dependency is used in regular code, rather than only in test submodules or Scribble docs.